### PR TITLE
Bugfix: Error while evaluating a Function Call, empty()

### DIFF
--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -76,9 +76,9 @@ define networkd::network(
   }
 
   $values = [
-    ['LinkLocalAddressing', $linklocaladdressing],
-    ['LLMNR', $llmnr],
-    ['DHCP', $dhcp],
+    ['LinkLocalAddressing', String($linklocaladdressing)],
+    ['LLMNR', String($llmnr)],
+    ['DHCP', String($dhcp)],
     ['Domains', join($domains, ' ')],
     ['DNS', join($dns, ' ')],
     ['Address', join($address, ' ')],


### PR DESCRIPTION
Removing the " to make lint happy introduced a bug, as the parameter undef is not converted to an empty string. Using the strings() function this gets corrected.

Signed-off-by: bjanssens <bjanssens@inuits.eu>